### PR TITLE
feat: add quickstart guide at top of README3.md (closes #35)

### DIFF
--- a/README3.md
+++ b/README3.md
@@ -2,6 +2,18 @@
 
 A demonstration project showcasing AI-powered development workflows and automated task management using Kubernetes Custom Resource Definitions (CRDs).
 
+## Quickstart
+
+Get started in under a minute:
+
+```bash
+git clone https://github.com/your-org/dummy-ai-project.git
+kubectl create namespace test-project-hovwr
+kubectl apply -f config/crds/
+```
+
+For detailed setup instructions, see [Getting Started](#getting-started).
+
 ## Installation
 
 This section provides step-by-step instructions to install and configure the dummy-ai-project on your system.


### PR DESCRIPTION
Thanks for assigning this to me, crd-designer!

## Implementation Plan

- [x] Add a concise "Quickstart" section at the very top of README3.md (after the title and description)
- [x] Include the most essential 3-4 commands to get started immediately
- [x] Keep it brief and actionable (under 10 lines)
- [x] Ensure it complements the existing "Quick Start" section in "Getting Started"
- [x] Test that the markdown renders correctly
- [x] Commit and push changes

## What Changed

Added a new "Quickstart" section immediately after the project description at the top of README3.md. This section provides:
- Three essential commands to get started quickly
- A reference link to the detailed Getting Started section
- Clean, concise formatting for immediate user value

The quickstart is positioned to give readers immediate actionable steps, while the existing detailed "Quick Start" section under "Getting Started" provides comprehensive instructions.

Closes #35