### PR TITLE
feat: Add Getting Started section to README3.md

### DIFF
--- a/README3.md
+++ b/README3.md
@@ -2,17 +2,42 @@
 
 A demonstration project showcasing AI-powered development workflows and automated task management using Kubernetes Custom Resource Definitions (CRDs).
 
-## Quickstart
+## Getting Started
 
-Get started in under a minute:
+This guide will help you set up and start using dummy-ai-project in minutes.
+
+### Quick Start
+
+Get up and running with these essential commands:
 
 ```bash
+# 1. Clone the repository
 git clone https://github.com/your-org/dummy-ai-project.git
+cd dummy-ai-project
+
+# 2. Verify prerequisites
+kubectl version --client
+gh --version
+
+# 3. Set up your Kubernetes environment
 kubectl create namespace test-project-hovwr
+
+# 4. Install Custom Resource Definitions
 kubectl apply -f config/crds/
+
+# 5. Verify installation
+kubectl get crds | grep coo.dev
 ```
 
-For detailed setup instructions, see [Getting Started](#getting-started).
+### Next Steps
+
+After completing the quick start:
+
+1. **Authenticate with GitHub**: Run `gh auth login` to enable GitHub integration
+2. **Explore tasks**: View existing tasks with `kubectl get cootasks -n test-project-hovwr`
+3. **Create your first task**: Follow the [Usage](#usage) guide to create and manage tasks
+
+For detailed installation instructions and troubleshooting, see the [Installation](#installation) section below.
 
 ## Installation
 
@@ -349,31 +374,24 @@ Before installing and using this project, ensure you have the following tools in
 - **GitHub authentication failed**: Run `gh auth login` and follow the prompts
 - **Namespace already exists**: This is expected if the namespace was created previously
 
-## Getting Started
+## Usage
 
 This project demonstrates automated development workflows. Tasks are managed through Kubernetes CRDs and automatically assigned to AI agents for implementation.
 
-### Quick Start
+### Working with Tasks
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/your-org/dummy-ai-project.git
-   cd dummy-ai-project
-   ```
-
-2. **View existing tasks**
+1. **View existing tasks**
    ```bash
    kubectl get cootasks -n test-project-hovwr
    ```
 
-3. **Check task status**
+2. **Check task status**
    ```bash
    kubectl describe cootask <task-name> -n test-project-hovwr
    ```
 
-### Usage
-
-Tasks are created as CooTask CRDs and automatically processed by designated AI agents. Each task follows a structured workflow from assignment through implementation to review.
+3. **Monitor task progress**
+   Tasks are automatically processed by designated AI agents. Each task follows a structured workflow from assignment through implementation to review.
 
 ## Workflow Example
 


### PR DESCRIPTION
Thanks for assigning this to me, crd-designer!

## Implementation Plan

- [x] Analyze existing README3.md structure to identify the best approach
- [x] Enhance the Getting Started section at the top with clear, actionable quick start commands
- [x] Add numbered steps for easy following (clone, verify prerequisites, setup K8s, install CRDs, verify)
- [x] Include Next Steps subsection with GitHub authentication and task exploration guidance
- [x] Remove duplicate Getting Started section that appeared later in the document
- [x] Test commands to ensure they are valid and work as expected
- [x] Commit and push changes

## Changes Made

The Getting Started section now appears prominently at the top of README3.md (right after the project description) with:

1. **Quick Start** subsection with 5 numbered steps:
   - Clone the repository
   - Verify prerequisites (kubectl and gh CLI)
   - Set up Kubernetes environment
   - Install Custom Resource Definitions
   - Verify installation

2. **Next Steps** subsection that guides users to:
   - Authenticate with GitHub
   - Explore existing tasks
   - Create their first task

3. Removed the duplicate Getting Started section that appeared later to avoid confusion

The section provides a clear, actionable path for new users to get up and running quickly, while linking to more detailed installation instructions for those who need them.

Closes #29